### PR TITLE
Fix header overlap on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <title>K-Pop Word Warrior: SSAT Vocabulary Quest</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&family=Poppins:wght@400;600;700;800&display=swap');
@@ -23,6 +23,8 @@
             color: #ffffff;
             min-height: 100vh;
             overflow-x: hidden;
+            padding-top: env(safe-area-inset-top);
+            padding-top: constant(safe-area-inset-top);
            /*position: relative;*/
         }
 

--- a/www/index.html
+++ b/www/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <title>K-Pop Word Warrior: SSAT Vocabulary Quest</title>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&family=Poppins:wght@400;600;700;800&display=swap');
@@ -23,6 +23,8 @@
             color: #ffffff;
             min-height: 100vh;
             overflow-x: hidden;
+            padding-top: env(safe-area-inset-top);
+            padding-top: constant(safe-area-inset-top);
            /*position: relative;*/
         }
 


### PR DESCRIPTION
Add iOS safe area support to prevent header overlap on iPhones.

The header previously overlapped with the iOS status bar (time, battery, etc.). This PR adds `viewport-fit=cover` to the viewport meta tag and applies `padding-top: env(safe-area-inset-top)` to the `body` element to correctly position content below the status bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-19d9faa8-ab39-4fda-9e30-385db8636232">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19d9faa8-ab39-4fda-9e30-385db8636232">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

